### PR TITLE
Fix bug in String.DefaultIfNullOrEmpty

### DIFF
--- a/src/Standard/dotNetTips.Utility.Standard.Extensions/StringExtensions.cs
+++ b/src/Standard/dotNetTips.Utility.Standard.Extensions/StringExtensions.cs
@@ -137,7 +137,7 @@ namespace dotNetTips.Utility.Standard.Extensions
         /// <param name="value">The value.</param>
         /// <param name="defaultValue">The default value.</param>
         /// <returns>System.String.</returns>
-        public static string DefaultIfNullOrEmpty(this string value, string defaultValue) => string.IsNullOrEmpty(value) ? value : defaultValue;
+        public static string DefaultIfNullOrEmpty(this string value, string defaultValue) => string.IsNullOrEmpty(value) ? defaultValue : value;
 
         /// <summary>
         /// Determines whether the specified input has value.


### PR DESCRIPTION
Currently the default is used if the string is NOT empty or null.
I'm guessing that's not what you intended.
